### PR TITLE
Add option to open specs in the same pane

### DIFF
--- a/lib/rails-open-rspec.coffee
+++ b/lib/rails-open-rspec.coffee
@@ -49,10 +49,11 @@ module.exports =
 
   openWithWrite: (openFilePath, sourceEditor) ->
     openOptions = {}
-    if @isSinglePane()
-      openOptions = { split: 'right' }
-    else
-      atom.workspace.activateNextPane()
+    if atom.config.get('rails-open-rspec.splitPane')
+      if @isSinglePane()
+        openOptions = { split: 'right' }
+      else
+        atom.workspace.activateNextPane()
 
     promise = atom.workspace.open(openFilePath, openOptions)
 

--- a/package.json
+++ b/package.json
@@ -13,5 +13,13 @@
   "engines": {
     "atom": ">=0.174.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "configSchema": {
+    "splitPane": {
+      "description": "Open specs side by side with code.",
+      "type": "boolean",
+      "default": true,
+      "order": 1
+    }
+  }
 }


### PR DESCRIPTION
When opening the specs, I prefer to have it open in the same pane instead of splitting my editor.

The PR defaults to splitting the editor, but allows you to turn off that behavior if you want the specs opening within the same pane.
