### PR TITLE
Create lib specs under specs folder

### DIFF
--- a/lib/rails-open-rspec.coffee
+++ b/lib/rails-open-rspec.coffee
@@ -31,9 +31,11 @@ module.exports =
 
     if @isSpecFile(relativePath)
       openFilePath = relativePath.replace /\_spec\.rb$/, '.rb'
+      openFilePath = openFilePath.replace /^\/spec\/lib\//, "/lib/"
       openFilePath = openFilePath.replace /^\/spec\//, "/app/"
     else
       openFilePath = relativePath.replace /\.rb$/, '_spec.rb'
+      openFilePath = openFilePath.replace /^\/lib\//, "/spec/lib/"
       openFilePath = openFilePath.replace /^\/app\//, "/spec/"
 
     if relativePath == openFilePath


### PR DESCRIPTION
When opening a spec for a file in `/lib`, look in `spec/lib` instead of `/lib`
